### PR TITLE
fix: init file system watcher lazily

### DIFF
--- a/wisp-resource-loader/src/main/kotlin/wisp/resources/FilesystemLoaderBackend.kt
+++ b/wisp-resource-loader/src/main/kotlin/wisp/resources/FilesystemLoaderBackend.kt
@@ -24,7 +24,7 @@ object FilesystemLoaderBackend : ResourceLoader.Backend() {
      * So we track the watchers on directories and the file(s) we are wanting to watch in each one.
      */
 
-    private val watcher: WatchService = FileSystems.getDefault().newWatchService()
+    private val watcher: WatchService by lazy { FileSystems.getDefault().newWatchService() }
     private val threadGroup = ThreadGroup("FilesystemLoader")
 
     // for testing access


### PR DESCRIPTION
On docker on an M1 mac, when running an image built for Intel CPU under QEMU emulation, we get a crash because

> filesystem change notification APIs (inotify) do not work under qemu emulation

Example error:

```
backfila▏[main] ERROR ROOT - Uncaught exception!
backfila▏java.lang.ExceptionInInitializerError: null
... omitted ....
backfila▏at com.squareup.cash.cashbackfila.service.CashBackfilaServiceKt.main(CashBackfilaService.kt:55)
backfila▏Caused by: java.io.IOException: Function not implemented
backfila▏	at java.base/sun.nio.fs.LinuxWatchService.<init>(LinuxWatchService.java:64)
backfila▏	at java.base/sun.nio.fs.LinuxFileSystem.newWatchService(LinuxFileSystem.java:47)
backfila▏	at wisp.resources.FilesystemLoaderBackend.<clinit>(FilesystemLoaderBackend.kt:27)
backfila▏	... 10 common frames omitted
```

Right now this throws for any application using wisp. Initializing the `WatchService` lazily will cause this exception to only throw if the watcher is actually used.