### PR TITLE
Roll back AWS lib version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 assertj = "3.23.1"
-aws2 = "2.17.254"
+aws2 = "2.17.224"
 bouncycastle = "1.70"
 docker = "3.2.13"
 grpc = "1.48.1"


### PR DESCRIPTION
The new version is causing issues for flink app deployments, as
auth credentials in the Cash App environment are not getting picked
up properly. This appears to be a regression in the AWS lib, and we
will be filing an issue against the upstream about it. However for
now let's roll back to the known good version that we were on
previously.