### PR TITLE
Apply the AWS BOM to prevent AWS lib version mismatches

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,8 @@ versionsGradlePlugin = "0.42.0"
 
 [libraries]
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
-aws2Regions = { module = "software.amazon.awssdk:regions", version.ref = "aws2" }
+aws2Bom = { module = "software.amazon.awssdk:bom", version.ref = "aws2" }
+aws2Regions = { module = "software.amazon.awssdk:regions" } # omit the version so attempts to use this dep without the BOM fail
 bouncycastle = { module = "org.bouncycastle:bcprov-jdk15on", version.ref = "bouncycastle" }
 dockerCore = { module = "com.github.docker-java:docker-java-core", version.ref = "docker" }
 dockerTransport = { module = "com.github.docker-java:docker-java-transport-httpclient5", version.ref = "docker" }

--- a/wisp-aws-environment/build.gradle.kts
+++ b/wisp-aws-environment/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+    implementation(platform(libs.aws2Bom))
     implementation(libs.aws2Regions)
     api(project(":wisp-deployment"))
 


### PR DESCRIPTION
If downstream consumers are using different AWS libs from the SDK at different
versions, they may not work as intended. The solution is to ensure all libraries
that use the AWS SDK use a BOM to maintain version alignment.