### PR TITLE
Allow all tracer extensions to return values

### DIFF
--- a/wisp-tracing/api/wisp-tracing.api
+++ b/wisp-tracing/api/wisp-tracing.api
@@ -44,9 +44,9 @@ public final class wisp/tracing/TracerExtKt {
 
 public final class wisp/tracing/TracingKt {
 	public static final fun childSpan (Lio/opentracing/Tracer;Ljava/lang/String;Lio/opentracing/Span;)Lio/opentracing/Span;
-	public static final fun scoped (Lio/opentracing/Tracer;Lio/opentracing/Span;ZLkotlin/jvm/functions/Function1;)V
-	public static synthetic fun scoped$default (Lio/opentracing/Tracer;Lio/opentracing/Span;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static final fun spanned (Lio/opentracing/Tracer;Ljava/lang/String;ZZLkotlin/jvm/functions/Function1;)V
-	public static synthetic fun spanned$default (Lio/opentracing/Tracer;Ljava/lang/String;ZZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun scoped (Lio/opentracing/Tracer;Lio/opentracing/Span;ZLkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun scoped$default (Lio/opentracing/Tracer;Lio/opentracing/Span;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun spanned (Lio/opentracing/Tracer;Ljava/lang/String;ZZLkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun spanned$default (Lio/opentracing/Tracer;Ljava/lang/String;ZZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
 }
 


### PR DESCRIPTION
This is a backward compatible change, since it simply adds an optional return type to the API.