### PR TITLE
Fix potential NPE

### DIFF
--- a/wisp-resource-loader/src/main/kotlin/wisp/resources/ClasspathResourceLoaderBackend.kt
+++ b/wisp-resource-loader/src/main/kotlin/wisp/resources/ClasspathResourceLoaderBackend.kt
@@ -19,7 +19,7 @@ object ClasspathResourceLoaderBackend : ResourceLoader.Backend() {
         require(path.startsWith("/"))
         val checkPath = path.removePrefix("/").removeSuffix("/")
 
-        val classLoader = Thread.currentThread().contextClassLoader
+        val classLoader = classLoader()
         val result = mutableSetOf<String>()
         for (url in classLoader.getResources(checkPath)) {
             val urlString = url.toString()
@@ -83,13 +83,15 @@ object ClasspathResourceLoaderBackend : ResourceLoader.Backend() {
     }
 
     override fun open(path: String): BufferedSource? {
-        val classLoader = Thread.currentThread().contextClassLoader
-        val resourceAsStream = classLoader.getResourceAsStream(path.removePrefix("/")) ?: return null
+        val resourceAsStream = classLoader().getResourceAsStream(path.removePrefix("/")) ?: return null
         return resourceAsStream.source().buffer()
     }
 
     override fun exists(path: String): Boolean {
-        val classLoader = Thread.currentThread().contextClassLoader
-        return classLoader.getResource(path.removePrefix("/")) != null
+        return classLoader().getResource(path.removePrefix("/")) != null
+    }
+
+    private fun classLoader() : ClassLoader {
+        return Thread.currentThread().contextClassLoader ?: ClassLoader.getSystemClassLoader()
     }
 }

--- a/wisp-resource-loader/src/test/kotlin/wisp/resources/ResourceLoaderTest.kt
+++ b/wisp-resource-loader/src/test/kotlin/wisp/resources/ResourceLoaderTest.kt
@@ -47,6 +47,14 @@ class ResourceLoaderTest {
     }
 
     @Test
+    fun loadResourceWithSystemClassLoader() {
+        withContextClassLoader(null) {
+          val resource = resourceLoader.utf8("classpath:/wisp/resources/ResourceLoaderTest.txt")!!
+          assertThat(resource).isEqualTo("69e0753934d2838d1953602ca7722444\n")
+        }
+    }
+
+    @Test
     fun absentResource() {
         assertThat(resourceLoader.utf8("classpath:/wisp/resources/NoSuchResource.txt")).isNull()
     }
@@ -311,7 +319,7 @@ class ResourceLoaderTest {
             .isFalse()
     }
 
-    private fun <T> withContextClassLoader(classLoader: ClassLoader, block: () -> T): T {
+    private fun <T> withContextClassLoader(classLoader: ClassLoader?, block: () -> T): T {
         val previousContextClassLoader = Thread.currentThread().contextClassLoader
         Thread.currentThread().contextClassLoader = classLoader
         try {


### PR DESCRIPTION
The contextClassLoader can be null. Per the Javadoc, this can happen to indicate the system classloader should be used instead. This patch updates the code to fall back to the system classloader if the context classloader is null.