### PR TITLE
Update RELEASING.md with some more explicit instructions

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,19 +9,25 @@ as a template to copy.
 
 ### Steps
 
-1. Check out a new branch. Update `CHANGELOG.md` with changes since the last release. This
-   step is manual and somewhat tedious. Follow the existing CHANGELOG.md format.
+1. Set versions:
 
-2. Set versions:
-
-    ```
+    ```sh
     export RELEASE_VERSION=A.B.C
     export NEXT_VERSION=A.B.D-SNAPSHOT
     ```
 
-3. Update documentation and Gradle properties with `RELEASE_VERSION`
+2. Check out the release branch.
 
+    ```sh
+    git checkout -b release-$RELEASE_VERSION
     ```
+
+3. Update `CHANGELOG.md` with changes since the last release. This
+   step is manual and somewhat tedious. Follow the existing `CHANGELOG.md` format.
+
+4. Update documentation and Gradle properties with `RELEASE_VERSION`
+
+    ```sh
     sed -i "" \
       "s/VERSION_NAME=.*/VERSION_NAME=$RELEASE_VERSION/g" \
       gradle.properties
@@ -30,23 +36,31 @@ as a template to copy.
       `find . -maxdepth 2 -name "README.md"`
     ```
 
-4. Tag the release and push to GitHub. Submit and merge PR.
+5. Tag the release and push to GitHub. Submit and merge PR.
 
-    ```
+    ```sh
     git commit -am "Prepare for release $RELEASE_VERSION."
     git tag -a wisp-$RELEASE_VERSION -m "Version $RELEASE_VERSION"
     git push && git push --tags
     # Then create PR and merge it
     ``` 
 
-5. Trigger the "Publish a release" action manually. Wait until it completes, then visit [Sonatype Nexus](https://oss.sonatype.org/)
+6. Trigger the "Publish a release" action manually. Wait until it completes, then visit [Sonatype Nexus](https://oss.sonatype.org/)
    to publish the artifacts. Follow the guide [here](https://central.sonatype.org/publish/release/) for detailed steps
    on how to promote (close then release) the artifact. Or drop it if there is a problem! Be warned, the UI is awful and
    may take much time to load the staging repository list.
 
-6. In a new branch, prepare for the next release and push to GitHub. Submit and merge PR.
+7. Checkout `main` branch and pull the latest changes
 
+    ```sh
+    git checkout main
+    git pull
     ```
+
+8. In a new branch, prepare for the next release and push to GitHub. Submit and merge PR.
+
+    ```sh
+    git checkout -b next-version-$NEXT_VERSION
     sed -i "" \
       "s/VERSION_NAME=.*/VERSION_NAME=$NEXT_VERSION/g" \
       gradle.properties
@@ -55,7 +69,8 @@ as a template to copy.
     # The create PR and merge it
     ```
 
-7. Draft a new [release](https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository) of `A.B.C` and publish it.
+9. Draft a new [release](https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository) of `A.B.C` and publish it.
+    - (Trialing) Copy release notes added to `CHANGELOG.md` in step 1 into Github release.
 
 ## Troubleshooting
 


### PR DESCRIPTION
These are just some updates to the instructions from notes taken when @chris-ryan-square walked me through the process.

We also discussed copying the release notes into the github release, which you can see an example of [here](https://github.com/cashapp/wisp/releases/tag/wisp-1.1.0).  I've added it to the instructions as `(Trialing)` for now and we can talk about whether or not we want to continue this practice later.