### PR TITLE
Upgrade launch darkly client from 5.8.1 -> 5.10.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ kotlinLogging = "3.0.2"
 kotlinRetry = "1.0.9"
 kotlinx = "1.6.4"
 # @pin
-launchDarkly = "5.8.1"
+launchDarkly = "5.10.1"
 logback = "1.4.4"
 # @pin
 mavenPublishGradlePlugin = "0.18.0"


### PR DESCRIPTION
Similar change in Misk: https://github.com/cashapp/misk/pull/2507 
Upgrade LaunchDarkly client to fix security vulnerability and memory issues. See https://github.com/launchdarkly/java-server-sdk/blob/main/CHANGELOG.md