### PR TITLE
Remove constraint on prometheus client dependency

### DIFF
--- a/wisp-bom/build.gradle.kts
+++ b/wisp-bom/build.gradle.kts
@@ -5,12 +5,6 @@ plugins {
 dependencies {
     constraints {
         // TODO - check constraints...
-
-        // Prometheus 0.10+ enforce _total in counters. Opt out of this version (but we should update
-        // and deal with this breaking change).
-        // See: https://github.com/prometheus/client_java/releases/tag/parent-0.10.0
-        api(libs.prometheusClient)
-
         project.rootProject.subprojects.forEach { subproject ->
             if (subproject.name != "wisp-bom") {
                 api(subproject)


### PR DESCRIPTION
This is not the right place for such a constraint, because wisp is a "generic library" and shouldn't dictate things for downstream consumers.