### PR TITLE
fix: make use of gradle catalog libs in subprojects

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,11 +38,11 @@ subprojects {
 
     if (!path.startsWith(":wisp-bom")) {
         apply(plugin = "kotlin")
-        apply(plugin = "org.jetbrains.kotlinx.binary-compatibility-validator")
-        apply(plugin = "com.google.protobuf")
+        apply(plugin = rootProject.project.libs.plugins.kotlinBinaryCompatibilityPlugin.get().pluginId)
+        apply(plugin = rootProject.project.libs.plugins.protobufGradlePlugin.get().pluginId)
     }
 
-    apply(plugin = "com.vanniktech.maven.publish")
+    apply(plugin = rootProject.project.libs.plugins.mavenPublishGradlePlugin.get().pluginId)
     apply(from = "$rootDir/gradle-mvn-publish.gradle")
     apply(plugin = "version-catalog")
 

--- a/gradle-mvn-publish.gradle
+++ b/gradle-mvn-publish.gradle
@@ -1,6 +1,6 @@
-apply plugin: "com.vanniktech.maven.publish"
+apply plugin: libs.plugins.mavenPublishGradlePlugin.get().pluginId
 
-plugins.withId("com.vanniktech.maven.publish") {
+plugins.withId(libs.plugins.mavenPublishGradlePlugin.get().pluginId) {
     mavenPublish {
         sonatypeHost="DEFAULT"
         releaseSigningEnabled = !getGpgKey().isEmpty()


### PR DESCRIPTION
making `libs` in Gradle Catalog  available to `subprojects` block (will be the same as `allprojects`) in `build.gradle.kts` via `rootProject.project.libs` as suggested in Gradle's comment.

https://github.com/gradle/gradle/issues/16634#issuecomment-809345790