### PR TITLE
Make retryOnConnectionFailure configurable

### DIFF
--- a/wisp-client/api/wisp-client.api
+++ b/wisp-client/api/wisp-client.api
@@ -5,12 +5,13 @@ public abstract interface class wisp/client/EnvoyClientEndpointProvider {
 
 public final class wisp/client/HttpClientConfig {
 	public fun <init> ()V
-	public fun <init> (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lwisp/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lwisp/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lwisp/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lwisp/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/time/Duration;
 	public final fun component10 ()Lwisp/client/HttpClientSSLConfig;
 	public final fun component11 ()Ljava/lang/String;
 	public final fun component12 ()Ljava/util/List;
+	public final fun component13 ()Ljava/lang/Boolean;
 	public final fun component2 ()Ljava/time/Duration;
 	public final fun component3 ()Ljava/time/Duration;
 	public final fun component4 ()Ljava/time/Duration;
@@ -19,8 +20,8 @@ public final class wisp/client/HttpClientConfig {
 	public final fun component7 ()Ljava/lang/Integer;
 	public final fun component8 ()Ljava/lang/Integer;
 	public final fun component9 ()Ljava/time/Duration;
-	public final fun copy (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lwisp/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;)Lwisp/client/HttpClientConfig;
-	public static synthetic fun copy$default (Lwisp/client/HttpClientConfig;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lwisp/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lwisp/client/HttpClientConfig;
+	public final fun copy (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lwisp/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;)Lwisp/client/HttpClientConfig;
+	public static synthetic fun copy$default (Lwisp/client/HttpClientConfig;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lwisp/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lwisp/client/HttpClientConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCallTimeout ()Ljava/time/Duration;
 	public final fun getConnectTimeout ()Ljava/time/Duration;
@@ -31,6 +32,7 @@ public final class wisp/client/HttpClientConfig {
 	public final fun getPingInterval ()Ljava/time/Duration;
 	public final fun getProtocols ()Ljava/util/List;
 	public final fun getReadTimeout ()Ljava/time/Duration;
+	public final fun getRetryOnConnectFailure ()Ljava/lang/Boolean;
 	public final fun getSsl ()Lwisp/client/HttpClientSSLConfig;
 	public final fun getUnixSocketFile ()Ljava/lang/String;
 	public final fun getWriteTimeout ()Ljava/time/Duration;

--- a/wisp-client/api/wisp-client.api
+++ b/wisp-client/api/wisp-client.api
@@ -32,7 +32,7 @@ public final class wisp/client/HttpClientConfig {
 	public final fun getPingInterval ()Ljava/time/Duration;
 	public final fun getProtocols ()Ljava/util/List;
 	public final fun getReadTimeout ()Ljava/time/Duration;
-	public final fun getRetryOnConnectFailure ()Ljava/lang/Boolean;
+	public final fun getRetryOnConnectionFailure ()Ljava/lang/Boolean;
 	public final fun getSsl ()Lwisp/client/HttpClientSSLConfig;
 	public final fun getUnixSocketFile ()Ljava/lang/String;
 	public final fun getWriteTimeout ()Ljava/time/Duration;

--- a/wisp-client/src/main/kotlin/wisp/client/HttpClientFactory.kt
+++ b/wisp-client/src/main/kotlin/wisp/client/HttpClientFactory.kt
@@ -21,7 +21,7 @@ class HttpClientFactory constructor(
     fun create(config: HttpClientEndpointConfig): OkHttpClient {
         // TODO(mmihic): Cache, proxy, etc
         val builder = unconfiguredClient.newBuilder()
-        builder.retryOnConnectionFailure(config.clientConfig.retryOnConnectFailure ?: false)
+        builder.retryOnConnectionFailure(config.clientConfig.retryOnConnectionFailure ?: false)
         okHttpClientCommonConfigurator.configure(builder = builder, config = config)
         config.clientConfig.ssl?.let {
             val trustStore = sslLoader.loadTrustStore(it.trust_store)!!

--- a/wisp-client/src/main/kotlin/wisp/client/HttpClientFactory.kt
+++ b/wisp-client/src/main/kotlin/wisp/client/HttpClientFactory.kt
@@ -21,7 +21,7 @@ class HttpClientFactory constructor(
     fun create(config: HttpClientEndpointConfig): OkHttpClient {
         // TODO(mmihic): Cache, proxy, etc
         val builder = unconfiguredClient.newBuilder()
-        builder.retryOnConnectionFailure(false)
+        builder.retryOnConnectionFailure(config.clientConfig.retryOnConnectFailure ?: false)
         okHttpClientCommonConfigurator.configure(builder = builder, config = config)
         config.clientConfig.ssl?.let {
             val trustStore = sslLoader.loadTrustStore(it.trust_store)!!

--- a/wisp-client/src/main/kotlin/wisp/client/HttpClientFactory.kt
+++ b/wisp-client/src/main/kotlin/wisp/client/HttpClientFactory.kt
@@ -21,7 +21,6 @@ class HttpClientFactory constructor(
     fun create(config: HttpClientEndpointConfig): OkHttpClient {
         // TODO(mmihic): Cache, proxy, etc
         val builder = unconfiguredClient.newBuilder()
-        builder.retryOnConnectionFailure(config.clientConfig.retryOnConnectionFailure ?: false)
         okHttpClientCommonConfigurator.configure(builder = builder, config = config)
         config.clientConfig.ssl?.let {
             val trustStore = sslLoader.loadTrustStore(it.trust_store)!!

--- a/wisp-client/src/main/kotlin/wisp/client/HttpClientsConfig.kt
+++ b/wisp-client/src/main/kotlin/wisp/client/HttpClientsConfig.kt
@@ -102,7 +102,7 @@ data class HttpClientConfig(
     val ssl: HttpClientSSLConfig? = null,
     val unixSocketFile: String? = null,
     val protocols: List<String>? = null,
-    val retryOnConnectFailure: Boolean? = null
+    val retryOnConnectionFailure: Boolean? = null
 )
 
 fun HttpClientConfig.applyDefaults(other: HttpClientConfig) =
@@ -119,7 +119,7 @@ fun HttpClientConfig.applyDefaults(other: HttpClientConfig) =
         ssl = this.ssl ?: other.ssl,
         unixSocketFile = this.unixSocketFile ?: other.unixSocketFile,
         protocols = this.protocols ?: other.protocols,
-        retryOnConnectFailure = this.retryOnConnectFailure ?: other.retryOnConnectFailure
+        retryOnConnectionFailure = this.retryOnConnectionFailure ?: other.retryOnConnectionFailure
     )
 
 data class HttpClientEndpointConfig(

--- a/wisp-client/src/main/kotlin/wisp/client/HttpClientsConfig.kt
+++ b/wisp-client/src/main/kotlin/wisp/client/HttpClientsConfig.kt
@@ -101,7 +101,8 @@ data class HttpClientConfig(
     val keepAliveDuration: Duration? = null,
     val ssl: HttpClientSSLConfig? = null,
     val unixSocketFile: String? = null,
-    val protocols: List<String>? = null
+    val protocols: List<String>? = null,
+    val retryOnConnectFailure: Boolean? = null
 )
 
 fun HttpClientConfig.applyDefaults(other: HttpClientConfig) =
@@ -117,7 +118,8 @@ fun HttpClientConfig.applyDefaults(other: HttpClientConfig) =
         keepAliveDuration = this.keepAliveDuration ?: other.keepAliveDuration,
         ssl = this.ssl ?: other.ssl,
         unixSocketFile = this.unixSocketFile ?: other.unixSocketFile,
-        protocols = this.protocols ?: other.protocols
+        protocols = this.protocols ?: other.protocols,
+        retryOnConnectFailure = this.retryOnConnectFailure ?: other.retryOnConnectFailure
     )
 
 data class HttpClientEndpointConfig(

--- a/wisp-client/src/main/kotlin/wisp/client/OkHttpClientCommonConfigurator.kt
+++ b/wisp-client/src/main/kotlin/wisp/client/OkHttpClientCommonConfigurator.kt
@@ -15,6 +15,7 @@ class OkHttpClientCommonConfigurator {
         configurePingInterval(builder = builder, config = config)
         configureReadTimeout(builder = builder, config = config)
         configureWriteTimeout(builder = builder, config = config)
+        configureRetryOnConnectionFailure(builder = builder, config = config)
         return builder
     }
 
@@ -54,11 +55,23 @@ class OkHttpClientCommonConfigurator {
         config.clientConfig.writeTimeout?.let { builder.writeTimeout(it) }
     }
 
+    private fun configureRetryOnConnectionFailure(
+        builder: Builder,
+        config: HttpClientEndpointConfig,
+    ) {
+        builder.retryOnConnectionFailure(
+          config.clientConfig.retryOnConnectionFailure ?: retryOnConnectionFailure
+        )
+    }
+
     companion object {
         // Copied from okhttp3.ConnectionPool, as it does not provide "use default" option
         const val maxIdleConnections = 5
 
         // Copied from okhttp3.ConnectionPool, as it does not provide "use default" option
         val keepAliveDuration: Duration = Duration.ofMinutes(5)
+
+        // For backwards-compat with previous behavior of always setting this to false
+        const val retryOnConnectionFailure = false
     }
 }


### PR DESCRIPTION
Chasing down intermittent failures in a service when calling an external API, and would like to be able to configure OkHttp to retry on connection failures. 