### PR TITLE
bump launchdarkly sdk version to 5.10.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ kotlinLogging = "3.0.4"
 kotlinRetry = "1.0.9"
 kotlinx = "1.6.4"
 # @pin
-launchDarkly = "5.8.1"
+launchDarkly = "5.10.4"
 logback = "1.4.5"
 # @pin
 mavenPublishGradlePlugin = "0.18.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ kotlinLogging = "3.0.4"
 kotlinRetry = "1.0.9"
 kotlinx = "1.6.4"
 # @pin
-launchDarkly = "5.10.4"
+launchDarkly = "5.10.6"
 logback = "1.4.5"
 # @pin
 mavenPublishGradlePlugin = "0.18.0"

--- a/wisp-launchdarkly/src/main/kotlin/wisp/launchdarkly/LaunchDarklyClient.kt
+++ b/wisp-launchdarkly/src/main/kotlin/wisp/launchdarkly/LaunchDarklyClient.kt
@@ -27,8 +27,11 @@ object LaunchDarklyClient {
             .offline(config.offline)
             // Set wait to 0 to not block here. Block in service initialization instead.
             .startWait(Duration.ofMillis(0))
-            .dataSource(Components.streamingDataSource().baseURI(baseUri))
-            .events(Components.sendEvents().baseURI(baseUri))
+            .serviceEndpoints(
+                Components.serviceEndpoints()
+                    .streaming(baseUri)
+                    .events(baseUri)
+            )
 
         config.ssl?.let {
             val trustStore = sslLoader.loadTrustStore(config.ssl.trust_store)!!


### PR DESCRIPTION
[5.10.4](https://github.com/launchdarkly/java-server-sdk/releases/tag/5.10.4) should have fixed the underlying issue of 'sdk sometimes not getting flag updates'.