### PR TITLE
Make withTags logging function public

### DIFF
--- a/wisp-logging/src/main/kotlin/wisp/logging/Logging.kt
+++ b/wisp-logging/src/main/kotlin/wisp/logging/Logging.kt
@@ -96,7 +96,7 @@ fun KLogger.log(level: Level, th: Throwable, vararg tags: Tag, message: () -> An
     }
 }
 
-private fun withTags(vararg tags: Tag, f: () -> Unit) {
+fun withTags(vararg tags: Tag, f: () -> Unit) {
     // Establish MDC, saving prior MDC
     val priorMDC = tags.map { (k, v) ->
         val priorValue = MDC.get(k)


### PR DESCRIPTION
Many teams within Block/Cash copy the wisp `withTags` function and use it to wrap blocks of their own code in tags.

We have been working to make the existing tools and patterns for logging more consistent, and making `withTags` public is a very minor change but one small step in that direction.