### PR TITLE
Disallow setting both url and envoy client configs

### DIFF
--- a/wisp-client/src/main/kotlin/wisp/client/HttpClientsConfig.kt
+++ b/wisp-client/src/main/kotlin/wisp/client/HttpClientsConfig.kt
@@ -126,7 +126,11 @@ data class HttpClientEndpointConfig(
     val url: String? = null,
     val envoy: HttpClientEnvoyConfig? = null,
     val clientConfig: HttpClientConfig = HttpClientConfig()
-)
+) {
+    init {
+        require(url == null || envoy == null) { "Cannot set both url and envoy configs" }
+    }
+}
 
 data class HttpClientEnvoyConfig(
     val app: String,


### PR DESCRIPTION
There's no reason to allow `HttpClientEndpointConfig.url` and `HttpClientEndpointConfig.envoy` to both be set; it's nonsensical. If it happens, it's almost certainly due to misconfiguration, such as a bad merge of tiered config files like this:

```
myservice-common.yml

endpoints:
  fooservice:
    url: http://foo.service.com
```
```
myservice-production.yml

endpoints:
  fooservice:
    envoy: { app: "foo" }
```

**Behavior change:** This PR will cause an exception to be thrown early (like in service startup when config objects are built) rather than letting `HttpClientEndpointConfig.url` silently override `HttpClientEndpointConfig.envoy` in places [like this](https://github.com/cashapp/misk/blob/073e9fe0f8d18c1791f18ede9074867aa9ec5833/misk/src/main/kotlin/misk/client/HttpClientConfigUrlProvider.kt#L15-L18). This change will allow the problem to be caught by unit tests, or at least prevent the service from starting and taking traffic, rather than manifesting as surprising behavior after the service starts up.