### PR TITLE
add metrics for ldClient initialization

### DIFF
--- a/wisp-launchdarkly/api/wisp-launchdarkly.api
+++ b/wisp-launchdarkly/api/wisp-launchdarkly.api
@@ -3,6 +3,17 @@ public final class wisp/launchdarkly/LaunchDarklyClient {
 	public final fun createLaunchDarklyClient (Lwisp/launchdarkly/LaunchDarklyConfig;Lwisp/security/ssl/SslLoader;Lwisp/security/ssl/SslContextFactory;Lwisp/resources/ResourceLoader;)Lcom/launchdarkly/sdk/server/interfaces/LDClientInterface;
 }
 
+public final class wisp/launchdarkly/LaunchDarklyClientMetrics {
+	public static final field Companion Lwisp/launchdarkly/LaunchDarklyClientMetrics$Companion;
+	public static final field FAILED_COUNTER_NAME Ljava/lang/String;
+	public static final field HISTO_DURATION_NAME Ljava/lang/String;
+	public static final field SUCCESS_COUNTER_NAME Ljava/lang/String;
+	public fun <init> (Lio/micrometer/core/instrument/MeterRegistry;)V
+}
+
+public final class wisp/launchdarkly/LaunchDarklyClientMetrics$Companion {
+}
+
 public final class wisp/launchdarkly/LaunchDarklyConfig : wisp/config/Config {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lwisp/client/HttpClientSSLConfig;Z)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lwisp/client/HttpClientSSLConfig;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -46,7 +57,8 @@ public final class wisp/launchdarkly/LaunchDarklyDynamicConfig$Companion {
 
 public final class wisp/launchdarkly/LaunchDarklyFeatureFlags : wisp/feature/FeatureFlags {
 	public static final field Companion Lwisp/launchdarkly/LaunchDarklyFeatureFlags$Companion;
-	public fun <init> (Lcom/launchdarkly/sdk/server/interfaces/LDClientInterface;Lcom/squareup/moshi/Moshi;)V
+	public fun <init> (Lcom/launchdarkly/sdk/server/interfaces/LDClientInterface;Lcom/squareup/moshi/Moshi;Lio/micrometer/core/instrument/MeterRegistry;)V
+	public synthetic fun <init> (Lcom/launchdarkly/sdk/server/interfaces/LDClientInterface;Lcom/squareup/moshi/Moshi;Lio/micrometer/core/instrument/MeterRegistry;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun get (Lwisp/feature/BooleanFeatureFlag;)Z
 	public fun get (Lwisp/feature/DoubleFeatureFlag;)D
 	public fun get (Lwisp/feature/EnumFeatureFlag;)Ljava/lang/Enum;

--- a/wisp-launchdarkly/build.gradle.kts
+++ b/wisp-launchdarkly/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     api(libs.launchDarkly)
     api(libs.loggingApi)
+    api(libs.micrometerCore)
     api(libs.moshiCore)
     api(project(":wisp-client"))
     api(project(":wisp-config"))

--- a/wisp-launchdarkly/src/main/kotlin/wisp/launchdarkly/LaunchDarklyClientMetrics.kt
+++ b/wisp-launchdarkly/src/main/kotlin/wisp/launchdarkly/LaunchDarklyClientMetrics.kt
@@ -1,0 +1,32 @@
+package wisp.launchdarkly
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.DistributionSummary
+import io.micrometer.core.instrument.MeterRegistry
+
+class LaunchDarklyClientMetrics(meterRegistry: MeterRegistry) {
+
+  internal fun initializationDuration(
+    meterRegistry: MeterRegistry
+  ): DistributionSummary =
+    DistributionSummary.builder(HISTO_DURATION_NAME)
+      .description("count and duration in ms of ld client initialization")
+      .percentilePrecision(4)
+      .publishPercentiles(0.5, 0.75, 0.95, 0.99, 0.999)
+      .publishPercentileHistogram()
+      .register(meterRegistry)
+
+  internal val successCount: Counter = Counter.builder(SUCCESS_COUNTER_NAME)
+    .description("count of successful ld client initializations")
+    .register(meterRegistry)
+
+  internal val failedCount: Counter = Counter.builder(FAILED_COUNTER_NAME)
+    .description("count of ld client initialization failures")
+    .register(meterRegistry)
+
+  companion object {
+    const val HISTO_DURATION_NAME = "histo_ld_initialization_duration_ms"
+    const val SUCCESS_COUNTER_NAME = "ld_initialization_success_total"
+    const val FAILED_COUNTER_NAME = "ld_initialization_failed_total"
+  }
+}


### PR DESCRIPTION
This is an effort to have better observability about ldClient startup. 
Added 3 metrics in this PR:
1. success count
2. failed  count
3. initialization latency