### PR TITLE
Add key validation for strong feature flags

### DIFF
--- a/wisp-feature-testing/src/main/kotlin/wisp/feature/testing/FakeStrongFeatureFlags.kt
+++ b/wisp-feature-testing/src/main/kotlin/wisp/feature/testing/FakeStrongFeatureFlags.kt
@@ -81,6 +81,9 @@ class FakeStrongFeatureFlags : StrongFeatureFlags {
     ): FakeStrongFeatureFlags = overrideAny(Flag::class.java, value, matcher)
 
     private fun <T : Any> getAny(flag: FeatureFlag<T>): T {
+        // Run standard validations against the feature
+        FeatureFlagValidation.checkValidKey(flag.feature, flag.key)
+
         val featureConfig = getFeatureConfig(flag.javaClass)
         return featureConfig.matchers.lastOrNull() { it.condition(flag) }?.value
             ?: error("no flag match found for $flag")


### PR DESCRIPTION
This change is the result of a cash SEV in which we attempted to access a default flag value with an empty string, which caused the validation exception in prod but was not registered in tests.