### PR TITLE
add logs for launchdarkly client startup

### DIFF
--- a/wisp-launchdarkly/src/main/kotlin/wisp/launchdarkly/LaunchDarklyFeatureFlags.kt
+++ b/wisp-launchdarkly/src/main/kotlin/wisp/launchdarkly/LaunchDarklyFeatureFlags.kt
@@ -43,7 +43,9 @@ class LaunchDarklyFeatureFlags @JvmOverloads constructor(
 
             if (attempts == 0 && !ldClient.isInitialized) {
                 launchDarklyClientMetrics.failedCount.increment()
-                throw Exception("LaunchDarkly did not initialize in 30 seconds")
+                val errorMessage = "LaunchDarkly did not initialize in 30 seconds"
+                logger.error { errorMessage }
+                throw Exception(errorMessage)
             }
 
             // ldClient successfully initialized
@@ -52,7 +54,7 @@ class LaunchDarklyFeatureFlags @JvmOverloads constructor(
         launchDarklyClientMetrics
             .initializationDuration(meterRegistry)
             .record(timedResult.toDouble())
-
+        logger.info { "LaunchDarkly successfully initialized in ${timedResult.toDouble()} seconds" }
         return this
     }
 

--- a/wisp-launchdarkly/src/main/kotlin/wisp/launchdarkly/LaunchDarklyFeatureFlags.kt
+++ b/wisp-launchdarkly/src/main/kotlin/wisp/launchdarkly/LaunchDarklyFeatureFlags.kt
@@ -43,7 +43,7 @@ class LaunchDarklyFeatureFlags @JvmOverloads constructor(
 
             if (attempts == 0 && !ldClient.isInitialized) {
                 launchDarklyClientMetrics.failedCount.increment()
-                val errorMessage = "LaunchDarkly did not initialize in 30 seconds"
+                val errorMessage = "LaunchDarkly did not initialize in 30 seconds."
                 logger.error { errorMessage }
                 throw Exception(errorMessage)
             }


### PR DESCRIPTION
newly added metrics were not able to show on DD, more details see: https://cash.slack.com/archives/C915WS04Q/p1686181943851789?thread_ts=1686157790.750109&cid=C915WS04Q

The multiple indirection of skim->misk->wisp drove me crazy that I have no idea how to override wisp code locally and test it out. Adding logs to help debug.