### PR TITLE
[CCPOKR-8236] Fix certificate error

### DIFF
--- a/wisp-ssl/src/main/kotlin/wisp/security/ssl/PemComboFile.kt
+++ b/wisp-ssl/src/main/kotlin/wisp/security/ssl/PemComboFile.kt
@@ -69,10 +69,8 @@ data class PemComboFile(
                             Regex("-+END PRIVATE KEY-+")
                         )
                     }
-                    line.isBlank() -> {
-                        // This is ok, just keep going
-                    }
-                    else -> throw IOException("unexpected line: $line")
+
+                    // Ignore everything else
                 }
             }
 


### PR DESCRIPTION
Issue: The certificate file has a custom parser that was raising an exception if unknown fields are found. This was failing because new fields (Valid/Subject/Issuer) were added to the certificate.

Fix: Ignore all fields except the part between BEGIN and END lines.